### PR TITLE
Fix SWF Tester

### DIFF
--- a/source/swf-tester/runner.html
+++ b/source/swf-tester/runner.html
@@ -6,7 +6,7 @@
             overflow: hidden;
         }
     </style>
-    <script src="https://awayfl.github.io/away-player-embed/dist/runtime.js" type="application/javascript"></script>
+    <script src="https://awayfl.github.io/awayfl-embed/dist/runtime.js" type="application/javascript"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Renaming the Embed renamed it's github pages that broke where the SWF Tester pulls the js from